### PR TITLE
typo configuration + add border and spacing to tables

### DIFF
--- a/source/_assets/sass/_documentation.scss
+++ b/source/_assets/sass/_documentation.scss
@@ -1,1 +1,17 @@
 // Add your custom styles here
+
+main div.w-full table {
+  @apply .w-full;
+}
+
+td, th {
+  @apply .border .py-1 .px-3;
+}
+
+td:first-child {
+  @apply .w-1/6;
+}
+
+td:last-child {
+  @apply .italic;
+}

--- a/source/docs/configuration.md
+++ b/source/docs/configuration.md
@@ -21,7 +21,7 @@ The `config/app.php` contains information related to your application:
 | name  | This value is the name of your application
 | version  | This value determines the "version" your application is currently running in.
 | production  | This value determines the "environment" your application is currently running in.
-| providers  | he service providers listed here will be automatically loaded on your application.
+| providers  | The service providers listed here will be automatically loaded on your application.
 
 The default command of your application contains a list of commands. That list of commands
 can be configured using `config/commands.php`:


### PR DESCRIPTION
* Fix typo in configuration page.
* Add border and some spacing to tables (also on configuration page)

Used the tailwind apply stuff for the tables.