### PR TITLE
Fix wrong path in creating your own config example

### DIFF
--- a/source/docs/configuration.md
+++ b/source/docs/configuration.md
@@ -8,7 +8,7 @@ section: content
 # Configuration
 
 The `config` folder should contain your application config files. Files in this folder
-are automatically registered as configuration files. As example, if you create an `app\bar.php`,
+are automatically registered as configuration files. As example, if you create an `config/bar.php`,
 you can access it using `config('bar')`.
 
 The configuration files `config/app.php` and `config/commands.php` are used internally by the


### PR DESCRIPTION
I'm just starting with Laravel Zero but hopefully I'm not crazy and this PR updates the path to something more correct.