### PR TITLE
Update filesystem doc to latest version of Laravel

### DIFF
--- a/source/docs/filesystem.md
+++ b/source/docs/filesystem.md
@@ -8,7 +8,7 @@ section: content
 ## Filesystem
 
 If you want to move files in your system, or to different providers like AwsS3 and Dropbox. By default,
-Laravel Zero ships with the [Filesystem](https://laravel.com/docs/5.7/filesystem) component of Laravel.
+Laravel Zero ships with the [Filesystem](https://laravel.com/docs/filesystem) component of Laravel.
 
 **Note:** By default the root directory is `your-app-name/storage/app`.
 


### PR DESCRIPTION
It was redirecting to 5.7. Now it redirects to 5.8 through removing the version number in the URL.