### PR TITLE
Fix the Command I/O url and update the defining-input-expectations

### DIFF
--- a/source/docs/commands.md
+++ b/source/docs/commands.md
@@ -67,7 +67,7 @@ to define how to gather input from the user through arguments or options:
                         {--age= : The age of the user (optional)}'
 ```
 
-For more information, check out the [Defining Input Expectations](https://laravel.com/docs/5.7/artisan#defining-input-expectations)
+For more information, check out the [Defining Input Expectations](https://laravel.com/docs/artisan#defining-input-expectations)
 on the Laravel Documentation.
 
 The `description` property should contain one line description of your command's job. Later, this description is
@@ -84,7 +84,7 @@ command is executed. Note that we are able to inject any dependencies we need in
     }
 ```
 
-The [Command I/O](https://laravel.com/docs/latest/artisan#command-io) topic in the Laravel Documentation, can help
+The [Command I/O](https://laravel.com/docs/artisan#command-io) topic in the Laravel Documentation, can help
 you to understand how to capture those input expectations and interact with the user using commands
 like `line`, `info`, `comment`, `question` and `error` methods.
 


### PR DESCRIPTION
This contains 2 urls for the commands page

Website url: https://laravel-zero.com/docs/commands/

The Command I/O points to https://laravel.com/docs/latest/artisan#command-io that redirects to a 404 ( https://laravel.com/docs/5.8/latest#command-io )

And I have updated the Defining Input Expectations to the url for latest Laravel version.

If wanted I can split this in multiple Pull requests (because it are 2 things on one page I wasn't sure if I need to create 1 or 2 pr's)